### PR TITLE
Add basic login and registration

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\User;
+
+class AuthController extends Controller
+{
+    public function showLogin()
+    {
+        return view('auth.login');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'name' => ['required', 'alpha_num'],
+            'password' => ['required'],
+        ]);
+
+        if (Auth::attempt($credentials)) {
+            $request->session()->regenerate();
+            return redirect()->intended('/');
+        }
+
+        return back()->withErrors([
+            'name' => 'Usuário ou senha incorretos.',
+        ])->onlyInput('name');
+    }
+
+    public function showRegister()
+    {
+        return view('auth.register');
+    }
+
+    public function register(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'alpha_num', 'max:255', 'unique:users,name'],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'min:8', 'confirmed'],
+        ]);
+
+        $user = User::create($validated);
+        Auth::login($user);
+
+        return redirect('/');
+    }
+
+    public function logout(Request $request)
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect('/login');
+    }
+}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex align-items-center justify-content-center vh-100">
+    <div class="w-100" style="max-width: 330px;">
+        <h1 class="h3 mb-3 fw-normal text-center">Login</h1>
+        @if ($errors->any())
+            <div class="alert alert-danger">{{ $errors->first() }}</div>
+        @endif
+        <form method="POST" action="{{ url('/login') }}">
+            @csrf
+            <div class="form-floating mb-2">
+                <input type="text" class="form-control" id="name" name="name" placeholder="Usuário" required>
+                <label for="name">Usuário</label>
+            </div>
+            <div class="form-floating mb-2">
+                <input type="password" class="form-control" id="password" name="password" placeholder="Senha" required>
+                <label for="password">Senha</label>
+            </div>
+            <button class="w-100 btn btn-lg btn-primary" type="submit">Entrar</button>
+        </form>
+        <p class="mt-3 text-center"><a href="{{ route('register') }}">Criar conta</a></p>
+    </div>
+</body>
+</html>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Cadastro</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex align-items-center justify-content-center vh-100">
+    <div class="w-100" style="max-width: 330px;">
+        <h1 class="h3 mb-3 fw-normal text-center">Cadastro</h1>
+        <form method="POST" action="{{ url('/register') }}">
+            @csrf
+            <div class="form-floating mb-2">
+                <input type="text" class="form-control" id="name" name="name" placeholder="Usuário" required>
+                <label for="name">Usuário</label>
+            </div>
+            <div class="form-floating mb-2">
+                <input type="email" class="form-control" id="email" name="email" placeholder="Email" required>
+                <label for="email">Email</label>
+            </div>
+            <div class="form-floating mb-2">
+                <input type="password" class="form-control" id="password" name="password" placeholder="Senha" required>
+                <label for="password">Senha</label>
+            </div>
+            <div class="form-floating mb-2">
+                <input type="password" class="form-control" id="password_confirmation" name="password_confirmation" placeholder="Confirmar Senha" required>
+                <label for="password_confirmation">Confirmar Senha</label>
+            </div>
+            <button class="w-100 btn btn-lg btn-primary" type="submit">Registrar</button>
+        </form>
+        <p class="mt-3 text-center"><a href="{{ route('login') }}">Entrar</a></p>
+    </div>
+</body>
+</html>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -77,15 +77,23 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom shadow-sm navbar-custom">
         <div class="container-fluid">
-            <div class="dropdown d-flex ms-auto">
-                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
-                    <i class="bi bi-person-circle fs-5"></i>
-                </a>
-                <ul class="dropdown-menu dropdown-menu-end">
-                    <li><a class="dropdown-item" href="#">Perfil</a></li>
-                    <li><a class="dropdown-item" href="#">Sair</a></li>
-                </ul>
-            </div>
+            @auth
+                <div class="dropdown d-flex ms-auto">
+                    <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+                        <i class="bi bi-person-circle fs-5"></i> {{ auth()->user()->name }}
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end">
+                        <li>
+                            <form method="POST" action="{{ route('logout') }}" class="d-inline">
+                                @csrf
+                                <button type="submit" class="dropdown-item">Sair</button>
+                            </form>
+                        </li>
+                    </ul>
+                </div>
+            @else
+                <a href="{{ route('login') }}" class="btn btn-link ms-auto">Entrar</a>
+            @endauth
         </div>
     </nav>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,9 +5,18 @@ use App\Http\Controllers\CustomerController;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\AuthController;
 
-Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
+Route::get('/login', [AuthController::class, 'showLogin'])->name('login');
+Route::post('/login', [AuthController::class, 'login']);
+Route::get('/register', [AuthController::class, 'showRegister'])->name('register');
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 
-Route::resource('customers', CustomerController::class);
-Route::resource('products', ProductController::class);
-Route::resource('orders', OrderController::class);
+Route::middleware('auth')->group(function () {
+    Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
+
+    Route::resource('customers', CustomerController::class);
+    Route::resource('products', ProductController::class);
+    Route::resource('orders', OrderController::class);
+});

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+test('user can register', function () {
+    $response = $this->post('/register', [
+        'name' => 'jogador1',
+        'email' => 'jogador1@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    $response->assertRedirect('/');
+    $this->assertDatabaseHas('users', ['name' => 'jogador1']);
+    $this->assertAuthenticated();
+});
+
+test('user can login', function () {
+    $user = User::create([
+        'name' => 'player',
+        'email' => 'player@example.com',
+        'password' => 'password',
+    ]);
+
+    $response = $this->post('/login', [
+        'name' => 'player',
+        'password' => 'password',
+    ]);
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($user);
+});


### PR DESCRIPTION
## Summary
- implement `AuthController` with register, login and logout logic
- create minimal login and registration views
- restrict app routes with `auth` middleware
- display login or user dropdown on layout
- add feature tests for basic authentication

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686538482ba883258a25ef44fc4b085e