### PR TITLE
Add dashboard pending delivery view

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -25,12 +25,21 @@ class DashboardController extends Controller
             ->groupBy('status')
             ->pluck('count', 'status');
 
+        $pendingDeliveryOrders = Order::where('status', '!=', 'entregue')
+            ->with('customer')
+            ->orderByDesc('updated_at')
+            ->get();
+
+        $pendingDeliveryCount = $pendingDeliveryOrders->count();
+
         return view('dashboard', [
             'customerCount' => $customerCount,
             'productCount'  => $productCount,
             'orderCount'    => $orderCount,
             'ordersByStatus' => $ordersByStatus,
             'totalPagosMes' => $totalPagosOuEntreguesMes,
+            'pendingDeliveryOrders' => $pendingDeliveryOrders,
+            'pendingDeliveryCount' => $pendingDeliveryCount,
         ]);
     }
 }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -60,5 +60,43 @@
             </div>
         </div>
     </div>
+
+    <div class="row mt-4">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header">
+                    Pedidos com entrega pendente ({{ $pendingDeliveryCount }})
+                </div>
+                <div class="card-body p-0">
+                    <table class="table mb-0">
+                        <thead>
+                            <tr>
+                                <th>Última atualização</th>
+                                <th>Cliente</th>
+                                <th>Contato</th>
+                                <th>Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($pendingDeliveryOrders as $order)
+                                <tr>
+                                    <td>{{ $order->updated_at->format('d/m/Y H:i') }}</td>
+                                    <td>{{ $order->customer->first_name }} {{ $order->customer->last_name }}</td>
+                                    <td>{{ $order->customer->phone }}</td>
+                                    <td>
+                                        <a href="{{ route('orders.edit', $order->id) }}" class="btn btn-sm btn-primary">Ver</a>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="4" class="text-center">Nenhum pedido pendente.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 @endsection

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -3,7 +3,7 @@
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
-uses(Tests\TestCase::class, RefreshDatabase::class);
+uses(RefreshDatabase::class);
 
 test('user can register', function () {
     $response = $this->post('/register', [

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
 test('dashboard route returns summary data', function () {
-    $response = $this->get('/');
+    $user = User::factory()->create();
+    $response = $this->actingAs($user)->get('/');
 
     $response->assertStatus(200)
         ->assertViewHasAll([
@@ -9,5 +15,7 @@ test('dashboard route returns summary data', function () {
             'productCount',
             'orderCount',
             'ordersByStatus',
+            'pendingDeliveryOrders',
+            'pendingDeliveryCount',
         ]);
 });

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
 test('the application returns a successful response', function () {
-    $response = $this->get('/');
+    $user = User::factory()->create();
+    $response = $this->actingAs($user)->get('/');
 
     $response->assertStatus(200);
 });


### PR DESCRIPTION
## Summary
- display orders with pending delivery on the dashboard
- show last update, customer name and contact with a button to open the order
- update tests to login user and verify new dashboard data

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6875647bff988325b40bf3bb40a1efde